### PR TITLE
To improve the overall layout of the Rock-Paper-Scissors game

### DIFF
--- a/my-project/src/Games/RockPaper Scissors/Game.css
+++ b/my-project/src/Games/RockPaper Scissors/Game.css
@@ -45,6 +45,7 @@
   .p {
     font-size: 2rem;
     margin: 1rem 0;
+    padding: 8px;
   }
   
   .score-board {
@@ -59,6 +60,7 @@
   
   .msg-container {
     margin-top: 2rem;
+    margin-bottom:8rem;
   }
   
   #msg {
@@ -68,4 +70,6 @@
     color: #fff;
     border-radius: 10px;
   }
-  
+  .footer-basic{
+    margin-top:90px;
+  }

--- a/my-project/src/Games/RockPaper Scissors/Game.jsx
+++ b/my-project/src/Games/RockPaper Scissors/Game.jsx
@@ -66,10 +66,11 @@ const RockPaperScissors = () => {
         </div>
       </div>
 
+
+      
       <div className="board">
-        <button className="reset" onClick={() => updateScore(0, 0)}>
-          Reset Score
-        </button>
+      
+        <p id="msg">{msg}</p>
         <p className="p">Wins</p>
         <div className="score-board">
           <div className="score">
@@ -84,7 +85,10 @@ const RockPaperScissors = () => {
       </div>
 
       <div className="msg-container">
-        <p id="msg">{msg}</p>
+      <button className="reset" onClick={() => updateScore(0, 0)}>
+          Reset Score
+        </button>
+       
       </div>
     </div>
     <Footer/>


### PR DESCRIPTION
### 🛠️ Fixes Issue
Closes #44 

### 👨‍💻 Description
 Rearrange the layout so that the message box and reset button are clearly and logically positioned. 
Add more spacing around the footer to separate it from the main game area, ensuring that it does not overlap or interfere with the core elements of the game.

### 📄 Type of Change
- [✅ ] Bug fix (non-breaking change which fixes an issue)
- [ ✅] New feature (non-breaking change which adds functionality)


### 📷 Screenshots/GIFs (if any)
![Screenshot (96)](https://github.com/user-attachments/assets/a75f39e7-25cd-4325-822a-a00bd09d1a3c)


### ✅ Checklist
- [✅ ] I am a participant of GSSoC-ext.
- [✅ ] I have followed the contribution guidelines of this project.
- [✅ ] I have viewed deployment of my code.
- [✅ ] My changes generate no new warnings.
- [✅ ] I have added documentation to explain my changes.

### 🤝 GSSoC Participation
- [✅ ] This PR is submitted under the GSSoC program.
- [ ✅] I have taken prior approval for this feature/fix.
